### PR TITLE
feat: implement get posts and create post with react query

### DIFF
--- a/src/features/post/hooks/usePosts.ts
+++ b/src/features/post/hooks/usePosts.ts
@@ -1,0 +1,23 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getPosts, createPost } from "@/features/post/services/postApi";
+
+export function usePosts() {
+  return useQuery({
+    queryKey: ["posts"],
+    queryFn: getPosts,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export function useCreatePost() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createPost,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["posts"],
+      });
+    },
+  });
+}

--- a/src/features/post/mappers/post.mapper.ts
+++ b/src/features/post/mappers/post.mapper.ts
@@ -1,0 +1,11 @@
+import type { PostDTO, Post } from "../types/post.types";
+
+export function mapPost(dto: PostDTO): Post {
+  return {
+    id: dto.id,
+    username: dto.username,
+    title: dto.title,
+    content: dto.content,
+    createdAt: new Date(dto.created_datetime),
+  };
+}

--- a/src/features/post/services/postApi.ts
+++ b/src/features/post/services/postApi.ts
@@ -1,0 +1,34 @@
+import { api } from "@/services/api";
+
+import { mapPost } from "../mappers/post.mapper";
+
+import type {
+  PostsResponseDTO,
+  CreatePostDTO,
+  PaginatedPosts,
+} from "@/features/post/types/post.types";
+
+export async function getPosts(): Promise<PaginatedPosts> {
+  const response = await api.get<PostsResponseDTO>("/");
+
+  const data = response.data;
+
+  return {
+    count: data.count,
+    next: data.next,
+    previous: data.previous,
+    posts: data.results.map(mapPost),
+  };
+}
+
+export async function createPost(data: CreatePostDTO) {
+  const response = await api.post("/", data);
+
+  //   const response = await fetch("/", {
+  //     method: "POST",
+  //     headers: { "Content-Type": "application/json" },
+  //     body: JSON.stringify(data),
+  //   });
+
+  console.log(response);
+}

--- a/src/features/post/types/post.types.ts
+++ b/src/features/post/types/post.types.ts
@@ -1,0 +1,35 @@
+export interface PostDTO {
+  id: number;
+  username: string;
+  created_datetime: string;
+  title: string;
+  content: string;
+}
+
+export interface PostsResponseDTO {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: PostDTO[];
+}
+
+export interface CreatePostDTO {
+  username: string;
+  title: string;
+  content: string;
+}
+
+export interface Post {
+  id: number;
+  username: string;
+  createdAt: Date;
+  title: string;
+  content: string;
+}
+
+export interface PaginatedPosts {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  posts: Post[];
+}

--- a/src/pages/Feed/FeedPage.tsx
+++ b/src/pages/Feed/FeedPage.tsx
@@ -1,3 +1,5 @@
+import { usePosts, useCreatePost } from "@/features/post/hooks/usePosts";
+
 import { Container } from "@/components/layout/Container/Container";
 import { Card } from "@/components/ui/Card/Card";
 import { Form } from "@/components/forms/Form/Form";
@@ -6,17 +8,24 @@ import { TextField } from "@/components/forms/Form/TextField/TextField";
 import { TextArea } from "@/components/forms/Form/TextArea/TextArea";
 import { Button } from "@/components/ui/Button/Button";
 
+import type { CreatePostDTO } from "@/features/post/types/post.types";
+
 import styles from "./styles.module.scss";
 
-interface FormValues {
-  title: string;
-  content: string;
-}
-
 export function FeedPage() {
-  function onFinish(values: FormValues) {
-    console.log(values);
-  }
+  const { data, isLoading } = usePosts();
+  const { mutate, isPending } = useCreatePost();
+
+  if (isLoading) return <span>Loading...</span>;
+
+  const onFinish = (values: CreatePostDTO) => {
+    const data = {
+      username: "Tom",
+      title: values?.title,
+      content: values?.content,
+    };
+    mutate(data);
+  };
 
   return (
     <Container className={styles.feedPage}>
@@ -36,6 +45,9 @@ export function FeedPage() {
           <Button type="submit" title="Create" handleClick={() => {}} />
         </Form>
       </Card>
+      {data?.posts?.map((post) => (
+        <div key={post.id}>{post.title}</div>
+      ))}
     </Container>
   );
 }


### PR DESCRIPTION
- Create getPosts service with axios
- Create createPost service with axios
- Add PostDTO and PostsResponseDTO types
- Implement post mapper (DTO to model)
- Create usePosts query hook
- Create useCreatePost mutation hook
- Integrate react query with posts API
- Handle cache invalidation after post creation